### PR TITLE
udpates for thread converting

### DIFF
--- a/force-app/main/default/classes/NKS_ConversationEntryController.cls
+++ b/force-app/main/default/classes/NKS_ConversationEntryController.cls
@@ -1,8 +1,11 @@
 public class NKS_ConversationEntryController {
     private static LoggerUtility logger = new LoggerUtility('Messaging');
-    // Welcome message text from the Messaging Component in Messaging Settings
-    private static final String welcomeMessageSubstringNO = 'Velkommen til chat med NAV';
-    private static final String welcomeMessageSubstringEN = 'Welcome to chat with NAV';
+    private static final String LOG_PREFIX = 'NKS_ConversationEntryController';
+
+    private static final String PREFIX_FRIDA = 'Frida:';
+    private static final String PREFIX_BRUKER = 'Bruker:';
+    private static final String PREFIX_VEILEDER = 'Veileder:';
+
     private static Map<String, User> navUserInfoByUserId = getNavUserInfoByUserId();
 
     public static void convertConversationEntries(
@@ -12,44 +15,138 @@ public class NKS_ConversationEntryController {
         String queryDirection,
         Integer recordLimit
     ) {
-        if (msgSessions.isEmpty()) {
-            return;
-        }
+        logger.info(
+            LOG_PREFIX +
+                '.convertConversationEntries START' +
+                ' | inputSessions=' +
+                (msgSessions == null ? null : msgSessions.size()) +
+                ' | startTimestamp=' +
+                startTimestamp +
+                ' | endTimestamp=' +
+                endTimestamp +
+                ' | queryDirection=' +
+                queryDirection +
+                ' | recordLimit=' +
+                recordLimit +
+                ' | runningUserId=' +
+                UserInfo.getUserId() +
+                ' | runningUserName=' +
+                UserInfo.getUserName(),
+            null,
+            CRM_ApplicationDomain.Domain.NKS
+        );
 
-        List<Id> messagingSessionIds = new List<Id>();
-        for (MessagingSession msgSession : msgSessions) {
-            messagingSessionIds.add(msgSession.Id);
-        }
-        List<MessagingSession> messagingSessions = [
-            SELECT
-                Id,
-                Conversation.ConversationIdentifier,
-                Endtime,
-                Status,
-                EndUserAccountId,
-                EndUserContactId,
-                EndUserLanguage,
-                NKS_Authentication_Timestamp__c
-            FROM MessagingSession
-            WHERE Id IN :messagingSessionIds
-        ];
-
-        for (MessagingSession session : messagingSessions) {
-            String conversationIdentifier = Test.isRunningTest()
-                ? '17978db9-ed91-4363-adcb-d1b581168eed'
-                : session.Conversation.ConversationIdentifier;
-            if (conversationIdentifier == null) {
-                continue;
+        try {
+            if (msgSessions == null || msgSessions.isEmpty()) {
+                logger.info(
+                    LOG_PREFIX + '.convertConversationEntries EXIT | No messaging sessions provided',
+                    null,
+                    CRM_ApplicationDomain.Domain.NKS
+                );
+                return;
             }
 
-            processConversationEntry(
-                session,
-                conversationIdentifier,
-                startTimestamp,
-                endTimestamp,
-                queryDirection,
-                recordLimit
+            List<Id> messagingSessionIds = new List<Id>();
+            for (MessagingSession msgSession : msgSessions) {
+                if (msgSession != null && msgSession.Id != null) {
+                    messagingSessionIds.add(msgSession.Id);
+                }
+            }
+
+            if (messagingSessionIds.isEmpty()) {
+                logger.info(
+                    LOG_PREFIX + '.convertConversationEntries EXIT | No valid messaging session ids',
+                    null,
+                    CRM_ApplicationDomain.Domain.NKS
+                );
+                return;
+            }
+
+            List<MessagingSession> messagingSessions = [
+                SELECT
+                    Id,
+                    ConversationId,
+                    Conversation.ConversationIdentifier,
+                    EndTime,
+                    Status,
+                    EndUserAccountId,
+                    EndUserContactId,
+                    EndUserLanguage,
+                    NKS_Authentication_Timestamp__c,
+                    CRM_Authentication_Status__c,
+                    CreatedDate
+                FROM MessagingSession
+                WHERE Id IN :messagingSessionIds
+            ];
+
+            logger.info(
+                LOG_PREFIX +
+                    '.convertConversationEntries | queriedMessagingSessions=' +
+                    JSON.serialize(messagingSessions),
+                null,
+                CRM_ApplicationDomain.Domain.NKS
             );
+
+            for (MessagingSession session : messagingSessions) {
+                try {
+                    if (session.CRM_Authentication_Status__c != 'Completed') {
+                        logger.info(
+                            LOG_PREFIX +
+                                '.convertConversationEntries | Skipping non-authenticated session' +
+                                ' | sessionId=' +
+                                session.Id +
+                                ' | authStatus=' +
+                                session.CRM_Authentication_Status__c,
+                            null,
+                            CRM_ApplicationDomain.Domain.NKS
+                        );
+                        continue;
+                    }
+
+                    String conversationIdentifier = Test.isRunningTest()
+                        ? '17978db9-ed91-4363-adcb-d1b581168eed'
+                        : session.Conversation.ConversationIdentifier;
+
+                    if (conversationIdentifier == null) {
+                        logger.error(
+                            LOG_PREFIX +
+                                '.convertConversationEntries | Skipping session because conversationIdentifier is null' +
+                                ' | sessionId=' +
+                                session.Id,
+                            null,
+                            CRM_ApplicationDomain.Domain.NKS
+                        );
+                        continue;
+                    }
+
+                    processConversationEntry(
+                        session,
+                        conversationIdentifier,
+                        startTimestamp,
+                        endTimestamp,
+                        queryDirection,
+                        recordLimit
+                    );
+                } catch (Exception sessionException) {
+                    logger.error(
+                        LOG_PREFIX +
+                            '.convertConversationEntries | Session processing failed' +
+                            ' | sessionId=' +
+                            session.Id +
+                            ' | message=' +
+                            sessionException.getMessage() +
+                            ' | stack=' +
+                            sessionException.getStackTraceString(),
+                        null,
+                        CRM_ApplicationDomain.Domain.NKS
+                    );
+                }
+            }
+        } catch (Exception e) {
+            logger.exception(e, CRM_ApplicationDomain.Domain.NKS);
+        } finally {
+            logger.info(LOG_PREFIX + '.convertConversationEntries END', null, CRM_ApplicationDomain.Domain.NKS);
+            logger.publish();
         }
     }
 
@@ -61,6 +158,17 @@ public class NKS_ConversationEntryController {
         String queryDirection,
         Integer recordLimit
     ) {
+        logger.info(
+            LOG_PREFIX +
+                '.processConversationEntry START' +
+                ' | sessionId=' +
+                session.Id +
+                ' | conversationIdentifier=' +
+                conversationIdentifier,
+            null,
+            CRM_ApplicationDomain.Domain.NKS
+        );
+
         try {
             HttpResponse response = NKS_ConversationEntryService.getConversationEntryMessages(
                 conversationIdentifier,
@@ -70,25 +178,66 @@ public class NKS_ConversationEntryController {
                 recordLimit
             );
 
+            logger.info(
+                LOG_PREFIX +
+                    '.processConversationEntry | HTTP response' +
+                    ' | sessionId=' +
+                    session.Id +
+                    ' | statusCode=' +
+                    response.getStatusCode() +
+                    ' | body=' +
+                    response.getBody(),
+                null,
+                CRM_ApplicationDomain.Domain.NKS
+            );
+
             if (response.getStatusCode() == 200) {
                 ConversationEntryWrapper wrapper = (ConversationEntryWrapper) JSON.deserialize(
                     response.getBody(),
                     ConversationEntryWrapper.class
                 );
+
+                logger.info(
+                    LOG_PREFIX +
+                        '.processConversationEntry | wrapper deserialized' +
+                        ' | sessionId=' +
+                        session.Id +
+                        ' | conversationEntriesSize=' +
+                        (wrapper == null ||
+                            wrapper.conversationEntries == null
+                            ? 0
+                            : wrapper.conversationEntries.size()),
+                    null,
+                    CRM_ApplicationDomain.Domain.NKS
+                );
+
                 createThreadMessages(wrapper, session);
             } else {
                 logger.httpError(
                     'Failed to get conversation entries for session: ' +
                         session.Id +
                         '.\nStatus Code: ' +
-                        response.getStatusCode(),
+                        response.getStatusCode() +
+                        '\nResponse Body: ' +
+                        response.getBody(),
                     response,
                     null,
                     CRM_ApplicationDomain.Domain.NKS
                 );
             }
         } catch (Exception e) {
-            logger.exception(e, CRM_ApplicationDomain.Domain.NKS);
+            logger.error(
+                LOG_PREFIX +
+                    '.processConversationEntry ERROR' +
+                    ' | sessionId=' +
+                    session.Id +
+                    ' | message=' +
+                    e.getMessage() +
+                    ' | stack=' +
+                    e.getStackTraceString(),
+                null,
+                CRM_ApplicationDomain.Domain.NKS
+            );
         } finally {
             logger.publish();
         }
@@ -101,29 +250,195 @@ public class NKS_ConversationEntryController {
 
         Thread__c thread = getThreadDetails(session.Id);
         if (thread == null) {
+            logger.error(
+                LOG_PREFIX + '.createThreadMessages EXIT | Thread not found | sessionId=' + session.Id,
+                null,
+                CRM_ApplicationDomain.Domain.NKS
+            );
             return;
         }
 
+        List<ConversationEntry> normalizedEntries = normalizeConversationEntries(wrapper.conversationEntries);
+
         List<ConversationEntry> chatbotMessages = new List<ConversationEntry>();
         List<ConversationEntry> userMessages = new List<ConversationEntry>();
-        splitChatbotMessagesFromConversation(wrapper.conversationEntries, chatbotMessages, userMessages);
+
+        splitChatbotMessagesFromConversation(normalizedEntries, chatbotMessages, userMessages);
 
         if (!chatbotMessages.isEmpty()) {
             thread.CRM_Additional_Information__c = formatChatbotMessagesAsString(chatbotMessages);
         }
 
-        List<Message__c> messagesToInsert = new List<Message__c>{ createAuthEventMessage(session, thread) };
+        List<Message__c> messagesToInsert = new List<Message__c>();
+
+        if (session.NKS_Authentication_Timestamp__c != null) {
+            messagesToInsert.add(createAuthEventMessage(session, thread));
+        }
 
         for (ConversationEntry entry : userMessages) {
-            if (entry.messageText != null) {
+            if (entry != null && !String.isBlank(entry.messageText)) {
                 messagesToInsert.add(createMessage(entry, session, thread));
             }
         }
 
+        logger.info(
+            LOG_PREFIX +
+                '.createThreadMessages | normalizedEntries.size=' +
+                normalizedEntries.size() +
+                ' | chatbotMessages.size=' +
+                chatbotMessages.size() +
+                ' | userMessages.size=' +
+                userMessages.size() +
+                ' | messagesToInsert.size=' +
+                messagesToInsert.size(),
+            null,
+            CRM_ApplicationDomain.Domain.NKS
+        );
+
         if (!messagesToInsert.isEmpty()) {
             insertMessages(messagesToInsert);
         }
+
         updateThread(thread);
+    }
+
+    private static List<ConversationEntry> normalizeConversationEntries(List<ConversationEntry> entries) {
+        List<ConversationEntry> normalizedEntries = new List<ConversationEntry>();
+
+        for (ConversationEntry entry : entries) {
+            if (entry == null || entry.messageText == null) {
+                normalizedEntries.add(entry);
+                continue;
+            }
+
+            String unescapedText = entry.messageText.unescapeHtml4();
+            List<String> splitLines = unescapedText.split('\n');
+
+            Boolean containsTranscriptLines = false;
+            for (String line : splitLines) {
+                String trimmedLine = line == null ? null : line.trim();
+                if (
+                    !String.isBlank(trimmedLine) &&
+                    (trimmedLine.startsWith(PREFIX_FRIDA) ||
+                    trimmedLine.startsWith(PREFIX_BRUKER) ||
+                    trimmedLine.startsWith(PREFIX_VEILEDER))
+                ) {
+                    containsTranscriptLines = true;
+                    break;
+                }
+            }
+
+            if (!containsTranscriptLines || splitLines.size() == 1) {
+                entry.messageText = unescapedText;
+                normalizedEntries.add(entry);
+                continue;
+            }
+
+            Integer lineIndex = 0;
+            for (String line : splitLines) {
+                String trimmedLine = line == null ? null : line.trim();
+                if (String.isBlank(trimmedLine)) {
+                    lineIndex++;
+                    continue;
+                }
+
+                ConversationEntry splitEntry = cloneConversationEntry(entry);
+                splitEntry.identifier = entry.identifier + '_' + String.valueOf(lineIndex);
+                splitEntry.messageText = trimmedLine;
+                splitEntry.sender = deriveSenderFromLinePrefix(trimmedLine, entry.sender);
+
+                normalizedEntries.add(splitEntry);
+                lineIndex++;
+            }
+        }
+
+        logger.info(
+            LOG_PREFIX +
+                '.normalizeConversationEntries | inputSize=' +
+                (entries == null ? 0 : entries.size()) +
+                ' | normalizedSize=' +
+                normalizedEntries.size(),
+            null,
+            CRM_ApplicationDomain.Domain.NKS
+        );
+
+        return normalizedEntries;
+    }
+
+    private static ConversationEntry cloneConversationEntry(ConversationEntry entry) {
+        ConversationEntry cloneEntry = new ConversationEntry();
+        cloneEntry.clientDuration = entry.clientDuration;
+        cloneEntry.clientTimestamp = entry.clientTimestamp;
+        cloneEntry.identifier = entry.identifier;
+        cloneEntry.messageText = entry.messageText;
+        cloneEntry.relatedRecords = entry.relatedRecords;
+        cloneEntry.serverReceivedTimestamp = entry.serverReceivedTimestamp;
+
+        if (entry.sender != null) {
+            cloneEntry.sender = new Sender();
+            cloneEntry.sender.appType = entry.sender.appType;
+            cloneEntry.sender.role = entry.sender.role;
+            cloneEntry.sender.subject = entry.sender.subject;
+        }
+
+        return cloneEntry;
+    }
+
+    private static Sender deriveSenderFromLinePrefix(String messageText, Sender originalSender) {
+        Sender sender = new Sender();
+
+        if (originalSender != null) {
+            sender.appType = originalSender.appType;
+            sender.role = originalSender.role;
+            sender.subject = originalSender.subject;
+        }
+
+        if (messageText.startsWith(PREFIX_FRIDA)) {
+            sender.role = 'System';
+            sender.subject = null;
+        } else if (messageText.startsWith(PREFIX_BRUKER)) {
+            sender.role = 'EndUser';
+        } else if (messageText.startsWith(PREFIX_VEILEDER)) {
+            sender.role = 'Agent';
+        }
+
+        return sender;
+    }
+
+    private static void splitChatbotMessagesFromConversation(
+        List<ConversationEntry> entries,
+        List<ConversationEntry> chatbotMessages,
+        List<ConversationEntry> userMessages
+    ) {
+        for (ConversationEntry entry : entries) {
+            if (entry == null || String.isBlank(entry.messageText)) {
+                continue;
+            }
+
+            String senderRole = entry.sender == null ? null : entry.sender.role;
+
+            logger.info(
+                LOG_PREFIX +
+                    '.splitChatbotMessagesFromConversation | identifier=' +
+                    entry.identifier +
+                    ' | senderRole=' +
+                    senderRole +
+                    ' | messageText=' +
+                    entry.messageText,
+                null,
+                CRM_ApplicationDomain.Domain.NKS
+            );
+
+            if (entry.messageText.startsWith(PREFIX_BRUKER) || entry.messageText.startsWith(PREFIX_VEILEDER)) {
+                userMessages.add(entry);
+            } else if (entry.messageText.startsWith(PREFIX_FRIDA)) {
+                chatbotMessages.add(entry);
+            } else if ('Agent'.equalsIgnoreCase(senderRole) || 'EndUser'.equalsIgnoreCase(senderRole)) {
+                userMessages.add(entry);
+            } else {
+                chatbotMessages.add(entry);
+            }
+        }
     }
 
     private static Message__c createAuthEventMessage(MessagingSession msgSession, Thread__c thread) {
@@ -134,7 +449,7 @@ public class NKS_ConversationEntryController {
         return new Message__c(
             CRM_Thread__c = thread.Id,
             CRM_Type__c = 'Event',
-            CRM_Sent_date__c = msgSession.NKS_Authentication_Timestamp__c,
+            CRM_Sent_Date__c = msgSession.NKS_Authentication_Timestamp__c,
             CRM_Read__c = true,
             CRM_Message_Text__c = authText
         );
@@ -143,13 +458,17 @@ public class NKS_ConversationEntryController {
     private static Message__c createMessage(ConversationEntry entry, MessagingSession session, Thread__c thread) {
         Message__c message = new Message__c();
         message.CRM_Thread__c = thread.Id;
-        message.CRM_Message_Text__c = entry.messageText;
-        message.CRM_Sent_Date__c = DateTime.newInstance(entry.serverReceivedTimestamp);
+        message.CRM_Message_Text__c = removeKnownPrefix(entry.messageText);
+        message.CRM_Sent_Date__c = entry.serverReceivedTimestamp == null
+            ? null
+            : DateTime.newInstance(entry.serverReceivedTimestamp);
         message.CRM_Read__c = true;
         message.CRM_Type__c = 'Message';
 
-        if ('Agent'.equals(entry.sender.role)) {
-            User navUser = navUserInfoByUserId.get(entry.sender.subject);
+        if (entry.messageText != null && entry.messageText.startsWith(PREFIX_VEILEDER)) {
+            String senderSubject = normalizeUserId(entry.sender == null ? null : entry.sender.subject);
+            User navUser = senderSubject == null ? null : navUserInfoByUserId.get(senderSubject);
+
             if (navUser != null) {
                 message.CRM_From_User__c = navUser.Id;
                 message.CRM_From_NAV_Unit__c = navUser.Department;
@@ -161,11 +480,38 @@ public class NKS_ConversationEntryController {
         return message;
     }
 
+    private static String removeKnownPrefix(String messageText) {
+        if (String.isBlank(messageText)) {
+            return messageText;
+        }
+
+        if (messageText.startsWith(PREFIX_FRIDA)) {
+            return messageText.substring(PREFIX_FRIDA.length()).trim();
+        }
+        if (messageText.startsWith(PREFIX_BRUKER)) {
+            return messageText.substring(PREFIX_BRUKER.length()).trim();
+        }
+        if (messageText.startsWith(PREFIX_VEILEDER)) {
+            return messageText.substring(PREFIX_VEILEDER.length()).trim();
+        }
+        return messageText;
+    }
+
     private static void insertMessages(List<Message__c> messages) {
         try {
             insert messages;
         } catch (Exception e) {
-            logger.error('Error inserting messages: ' + e.getMessage(), null, CRM_ApplicationDomain.Domain.NKS);
+            logger.error(
+                LOG_PREFIX +
+                    '.insertMessages ERROR | message=' +
+                    e.getMessage() +
+                    ' | stack=' +
+                    e.getStackTraceString() +
+                    ' | payload=' +
+                    JSON.serialize(messages),
+                null,
+                CRM_ApplicationDomain.Domain.NKS
+            );
         }
     }
 
@@ -175,61 +521,37 @@ public class NKS_ConversationEntryController {
             thread.CRM_Closed_Date__c = System.now();
             update thread;
         } catch (Exception e) {
-            logger.error('Error updating thread: ' + e.getMessage(), null, CRM_ApplicationDomain.Domain.NKS);
+            logger.error(
+                LOG_PREFIX +
+                    '.updateThread ERROR | threadId=' +
+                    thread.Id +
+                    ' | message=' +
+                    e.getMessage() +
+                    ' | stack=' +
+                    e.getStackTraceString(),
+                null,
+                CRM_ApplicationDomain.Domain.NKS
+            );
         }
-    }
-
-    private static void splitChatbotMessagesFromConversation(
-        List<ConversationEntry> entries,
-        List<ConversationEntry> chatbotMessages,
-        List<ConversationEntry> userMessages
-    ) {
-        Boolean automaticGreetingFound = false;
-        for (ConversationEntry entry : entries) {
-            if (entry.messageText == null) {
-                continue;
-            }
-            entry.messageText = entry.messageText.unescapeHtml4(); // Connect API returns HTML-encoded strings -> decode for further processing
-
-            if (!automaticGreetingFound && isWelcomeMessage(entry)) {
-                automaticGreetingFound = true;
-                entry.sender.role = 'Agent'; // Welcome message role is incorrectly set
-            }
-
-            if (automaticGreetingFound) {
-                userMessages.add(entry);
-            } else {
-                chatbotMessages.add(entry);
-            }
-        }
-    }
-
-    private static Boolean isWelcomeMessage(ConversationEntry entry) {
-        return entry.messageText != null &&
-            'System'.equalsIgnoreCase(entry.sender.role) &&
-            (entry.messageText.containsIgnoreCase(welcomeMessageSubstringEN) ||
-            entry.messageText.containsIgnoreCase(welcomeMessageSubstringNO));
     }
 
     private static String formatChatbotMessagesAsString(List<ConversationEntry> entries) {
         List<String> formattedMessages = new List<String>();
 
         for (ConversationEntry entry : entries) {
-            String messageText = entry.messageText;
-            // Assuming user sent more messages after chat was sent to queue
-            if (!messageText.startsWith('Bruker:') && !messageText.startsWith('Frida:')) {
-                messageText = 'Bruker: ' + messageText;
+            if (!String.isBlank(entry.messageText)) {
+                formattedMessages.add(entry.messageText);
             }
-            formattedMessages.add(messageText);
         }
 
         return String.join(formattedMessages, '\n');
     }
 
     private static Map<String, User> getNavUserInfoByUserId() {
-        Map<String, User> navUserInfoByUserId = new Map<String, User>();
+        Map<String, User> result = new Map<String, User>();
+
         for (User usr : [
-            SELECT Id, Department
+            SELECT Id, Department, CRM_NAV_Ident__c
             FROM User
             WHERE
                 ProfileId IN (SELECT Id FROM Profile WHERE Name LIKE 'NAV Kontaktsenter%')
@@ -237,19 +559,29 @@ public class NKS_ConversationEntryController {
                 AND CRM_NAV_Ident__c != NULL
                 AND CRM_NAV_Ident__c != ''
         ]) {
-            navUserInfoByUserId.put(usr.Id, usr);
+            result.put(normalizeUserId(String.valueOf(usr.Id)), usr);
         }
 
-        return navUserInfoByUserId;
+        return result;
+    }
+
+    private static String normalizeUserId(String userIdValue) {
+        if (String.isBlank(userIdValue)) {
+            return null;
+        }
+        return userIdValue.length() >= 15 ? userIdValue.left(15) : userIdValue;
     }
 
     private static Thread__c getThreadDetails(Id messagingSessionId) {
-        return [
-            SELECT Id, CRM_Additional_Information__c, CRM_isActive__c, CRM_Closed_Date__c
+        List<Thread__c> threads = [
+            SELECT Id, CRM_Related_Object__c, CRM_Additional_Information__c, CRM_isActive__c, CRM_Closed_Date__c
             FROM Thread__c
             WHERE CRM_Related_Object__c = :messagingSessionId
-            FOR UPDATE
+            ORDER BY CreatedDate DESC
+            LIMIT 1
         ];
+
+        return threads.isEmpty() ? null : threads[0];
     }
 
     public class ConversationEntryWrapper {

--- a/force-app/main/default/classes/NKS_ConversationEntryController.cls
+++ b/force-app/main/default/classes/NKS_ConversationEntryController.cls
@@ -221,7 +221,6 @@ public class NKS_ConversationEntryController {
 
         for (ConversationEntry entry : entries) {
             if (entry == null || String.isBlank(entry.messageText)) {
-                normalizedEntries.add(entry);
                 continue;
             }
 
@@ -465,15 +464,12 @@ public class NKS_ConversationEntryController {
     }
 
     private static Thread__c getThreadDetails(Id messagingSessionId) {
-        List<Thread__c> threads = [
-            SELECT Id, CRM_Related_Object__c, CRM_Additional_Information__c, CRM_isActive__c, CRM_Closed_Date__c
+        return [
+            SELECT Id, CRM_Additional_Information__c, CRM_isActive__c, CRM_Closed_Date__c
             FROM Thread__c
             WHERE CRM_Related_Object__c = :messagingSessionId
-            ORDER BY CreatedDate DESC
-            LIMIT 1
+            FOR UPDATE
         ];
-
-        return threads.isEmpty() ? null : threads[0];
     }
 
     public class ConversationEntryWrapper {

--- a/force-app/main/default/classes/NKS_ConversationEntryController.cls
+++ b/force-app/main/default/classes/NKS_ConversationEntryController.cls
@@ -15,34 +15,9 @@ public class NKS_ConversationEntryController {
         String queryDirection,
         Integer recordLimit
     ) {
-        logger.info(
-            LOG_PREFIX +
-                '.convertConversationEntries START' +
-                ' | inputSessions=' +
-                (msgSessions == null ? null : msgSessions.size()) +
-                ' | startTimestamp=' +
-                startTimestamp +
-                ' | endTimestamp=' +
-                endTimestamp +
-                ' | queryDirection=' +
-                queryDirection +
-                ' | recordLimit=' +
-                recordLimit +
-                ' | runningUserId=' +
-                UserInfo.getUserId() +
-                ' | runningUserName=' +
-                UserInfo.getUserName(),
-            null,
-            CRM_ApplicationDomain.Domain.NKS
-        );
 
         try {
             if (msgSessions == null || msgSessions.isEmpty()) {
-                logger.info(
-                    LOG_PREFIX + '.convertConversationEntries EXIT | No messaging sessions provided',
-                    null,
-                    CRM_ApplicationDomain.Domain.NKS
-                );
                 return;
             }
 
@@ -54,11 +29,6 @@ public class NKS_ConversationEntryController {
             }
 
             if (messagingSessionIds.isEmpty()) {
-                logger.info(
-                    LOG_PREFIX + '.convertConversationEntries EXIT | No valid messaging session ids',
-                    null,
-                    CRM_ApplicationDomain.Domain.NKS
-                );
                 return;
             }
 
@@ -79,27 +49,9 @@ public class NKS_ConversationEntryController {
                 WHERE Id IN :messagingSessionIds
             ];
 
-            logger.info(
-                LOG_PREFIX +
-                    '.convertConversationEntries | queriedMessagingSessions=' +
-                    JSON.serialize(messagingSessions),
-                null,
-                CRM_ApplicationDomain.Domain.NKS
-            );
-
             for (MessagingSession session : messagingSessions) {
                 try {
                     if (session.CRM_Authentication_Status__c != 'Completed') {
-                        logger.info(
-                            LOG_PREFIX +
-                                '.convertConversationEntries | Skipping non-authenticated session' +
-                                ' | sessionId=' +
-                                session.Id +
-                                ' | authStatus=' +
-                                session.CRM_Authentication_Status__c,
-                            null,
-                            CRM_ApplicationDomain.Domain.NKS
-                        );
                         continue;
                     }
 
@@ -110,7 +62,7 @@ public class NKS_ConversationEntryController {
                     if (conversationIdentifier == null) {
                         logger.error(
                             LOG_PREFIX +
-                                '.convertConversationEntries | Skipping session because conversationIdentifier is null' +
+                                '.convertConversationEntries | conversationIdentifier is null' +
                                 ' | sessionId=' +
                                 session.Id,
                             null,
@@ -145,7 +97,6 @@ public class NKS_ConversationEntryController {
         } catch (Exception e) {
             logger.exception(e, CRM_ApplicationDomain.Domain.NKS);
         } finally {
-            logger.info(LOG_PREFIX + '.convertConversationEntries END', null, CRM_ApplicationDomain.Domain.NKS);
             logger.publish();
         }
     }
@@ -158,17 +109,6 @@ public class NKS_ConversationEntryController {
         String queryDirection,
         Integer recordLimit
     ) {
-        logger.info(
-            LOG_PREFIX +
-                '.processConversationEntry START' +
-                ' | sessionId=' +
-                session.Id +
-                ' | conversationIdentifier=' +
-                conversationIdentifier,
-            null,
-            CRM_ApplicationDomain.Domain.NKS
-        );
-
         try {
             HttpResponse response = NKS_ConversationEntryService.getConversationEntryMessages(
                 conversationIdentifier,
@@ -178,41 +118,7 @@ public class NKS_ConversationEntryController {
                 recordLimit
             );
 
-            logger.info(
-                LOG_PREFIX +
-                    '.processConversationEntry | HTTP response' +
-                    ' | sessionId=' +
-                    session.Id +
-                    ' | statusCode=' +
-                    response.getStatusCode() +
-                    ' | body=' +
-                    response.getBody(),
-                null,
-                CRM_ApplicationDomain.Domain.NKS
-            );
-
-            if (response.getStatusCode() == 200) {
-                ConversationEntryWrapper wrapper = (ConversationEntryWrapper) JSON.deserialize(
-                    response.getBody(),
-                    ConversationEntryWrapper.class
-                );
-
-                logger.info(
-                    LOG_PREFIX +
-                        '.processConversationEntry | wrapper deserialized' +
-                        ' | sessionId=' +
-                        session.Id +
-                        ' | conversationEntriesSize=' +
-                        (wrapper == null ||
-                            wrapper.conversationEntries == null
-                            ? 0
-                            : wrapper.conversationEntries.size()),
-                    null,
-                    CRM_ApplicationDomain.Domain.NKS
-                );
-
-                createThreadMessages(wrapper, session);
-            } else {
+            if (response.getStatusCode() != 200) {
                 logger.httpError(
                     'Failed to get conversation entries for session: ' +
                         session.Id +
@@ -224,7 +130,15 @@ public class NKS_ConversationEntryController {
                     null,
                     CRM_ApplicationDomain.Domain.NKS
                 );
+                return;
             }
+
+            ConversationEntryWrapper wrapper = (ConversationEntryWrapper) JSON.deserialize(
+                response.getBody(),
+                ConversationEntryWrapper.class
+            );
+
+            createThreadMessages(wrapper, session);
         } catch (Exception e) {
             logger.error(
                 LOG_PREFIX +
@@ -260,40 +174,41 @@ public class NKS_ConversationEntryController {
 
         List<ConversationEntry> normalizedEntries = normalizeConversationEntries(wrapper.conversationEntries);
 
-        List<ConversationEntry> chatbotMessages = new List<ConversationEntry>();
-        List<ConversationEntry> userMessages = new List<ConversationEntry>();
-
-        splitChatbotMessagesFromConversation(normalizedEntries, chatbotMessages, userMessages);
-
-        if (!chatbotMessages.isEmpty()) {
-            thread.CRM_Additional_Information__c = formatChatbotMessagesAsString(chatbotMessages);
-        }
-
+        List<String> additionalInfoLines = new List<String>();
         List<Message__c> messagesToInsert = new List<Message__c>();
 
-        if (session.NKS_Authentication_Timestamp__c != null) {
-            messagesToInsert.add(createAuthEventMessage(session, thread));
-        }
+        Boolean agentChatStarted = false;
 
-        for (ConversationEntry entry : userMessages) {
-            if (entry != null && !String.isBlank(entry.messageText)) {
+        for (ConversationEntry entry : normalizedEntries) {
+            if (entry == null || String.isBlank(entry.messageText)) {
+                continue;
+            }
+
+            String senderRole = entry.sender == null ? null : entry.sender.role;
+
+            if (!agentChatStarted && 'Agent'.equalsIgnoreCase(senderRole)) {
+                agentChatStarted = true;
+            }
+
+            if (!agentChatStarted) {
+                additionalInfoLines.add(normalizeAdditionalInfoLine(entry));
+                continue;
+            }
+
+            if (isMessageEntry(entry)) {
                 messagesToInsert.add(createMessage(entry, session, thread));
+            } else {
+                additionalInfoLines.add(normalizeAdditionalInfoLine(entry));
             }
         }
 
-        logger.info(
-            LOG_PREFIX +
-                '.createThreadMessages | normalizedEntries.size=' +
-                normalizedEntries.size() +
-                ' | chatbotMessages.size=' +
-                chatbotMessages.size() +
-                ' | userMessages.size=' +
-                userMessages.size() +
-                ' | messagesToInsert.size=' +
-                messagesToInsert.size(),
-            null,
-            CRM_ApplicationDomain.Domain.NKS
-        );
+        if (!additionalInfoLines.isEmpty()) {
+            thread.CRM_Additional_Information__c = String.join(additionalInfoLines, '\n');
+        }
+
+        if (session.NKS_Authentication_Timestamp__c != null) {
+            messagesToInsert.add(0, createAuthEventMessage(session, thread));
+        }
 
         if (!messagesToInsert.isEmpty()) {
             insertMessages(messagesToInsert);
@@ -306,12 +221,12 @@ public class NKS_ConversationEntryController {
         List<ConversationEntry> normalizedEntries = new List<ConversationEntry>();
 
         for (ConversationEntry entry : entries) {
-            if (entry == null || entry.messageText == null) {
+            if (entry == null || String.isBlank(entry.messageText)) {
                 normalizedEntries.add(entry);
                 continue;
             }
 
-            String unescapedText = entry.messageText.unescapeHtml4();
+            String unescapedText = entry.messageText.unescapeHtml4().replace('\r\n', '\n');
             List<String> splitLines = unescapedText.split('\n');
 
             Boolean containsTranscriptLines = false;
@@ -329,7 +244,7 @@ public class NKS_ConversationEntryController {
             }
 
             if (!containsTranscriptLines || splitLines.size() == 1) {
-                entry.messageText = unescapedText;
+                entry.messageText = unescapedText.trim();
                 normalizedEntries.add(entry);
                 continue;
             }
@@ -351,16 +266,6 @@ public class NKS_ConversationEntryController {
                 lineIndex++;
             }
         }
-
-        logger.info(
-            LOG_PREFIX +
-                '.normalizeConversationEntries | inputSize=' +
-                (entries == null ? 0 : entries.size()) +
-                ' | normalizedSize=' +
-                normalizedEntries.size(),
-            null,
-            CRM_ApplicationDomain.Domain.NKS
-        );
 
         return normalizedEntries;
     }
@@ -405,40 +310,37 @@ public class NKS_ConversationEntryController {
         return sender;
     }
 
-    private static void splitChatbotMessagesFromConversation(
-        List<ConversationEntry> entries,
-        List<ConversationEntry> chatbotMessages,
-        List<ConversationEntry> userMessages
-    ) {
-        for (ConversationEntry entry : entries) {
-            if (entry == null || String.isBlank(entry.messageText)) {
-                continue;
-            }
-
-            String senderRole = entry.sender == null ? null : entry.sender.role;
-
-            logger.info(
-                LOG_PREFIX +
-                    '.splitChatbotMessagesFromConversation | identifier=' +
-                    entry.identifier +
-                    ' | senderRole=' +
-                    senderRole +
-                    ' | messageText=' +
-                    entry.messageText,
-                null,
-                CRM_ApplicationDomain.Domain.NKS
-            );
-
-            if (entry.messageText.startsWith(PREFIX_BRUKER) || entry.messageText.startsWith(PREFIX_VEILEDER)) {
-                userMessages.add(entry);
-            } else if (entry.messageText.startsWith(PREFIX_FRIDA)) {
-                chatbotMessages.add(entry);
-            } else if ('Agent'.equalsIgnoreCase(senderRole) || 'EndUser'.equalsIgnoreCase(senderRole)) {
-                userMessages.add(entry);
-            } else {
-                chatbotMessages.add(entry);
-            }
+    private static Boolean isMessageEntry(ConversationEntry entry) {
+        if (entry == null || String.isBlank(entry.messageText)) {
+            return false;
         }
+
+        String senderRole = entry.sender == null ? null : entry.sender.role;
+
+        return 'Agent'.equalsIgnoreCase(senderRole) || 'EndUser'.equalsIgnoreCase(senderRole);
+    }
+
+    private static String normalizeAdditionalInfoLine(ConversationEntry entry) {
+        if (entry == null || String.isBlank(entry.messageText)) {
+            return null;
+        }
+
+        String text = entry.messageText.trim();
+
+        if (text.startsWith(PREFIX_FRIDA) || text.startsWith(PREFIX_BRUKER) || text.startsWith(PREFIX_VEILEDER)) {
+            return text;
+        }
+
+        String senderRole = entry.sender == null ? null : entry.sender.role;
+
+        if ('EndUser'.equalsIgnoreCase(senderRole)) {
+            return PREFIX_BRUKER + ' ' + text;
+        }
+        if ('Agent'.equalsIgnoreCase(senderRole)) {
+            return PREFIX_VEILEDER + ' ' + text;
+        }
+
+        return PREFIX_FRIDA + ' ' + text;
     }
 
     private static Message__c createAuthEventMessage(MessagingSession msgSession, Thread__c thread) {
@@ -465,7 +367,9 @@ public class NKS_ConversationEntryController {
         message.CRM_Read__c = true;
         message.CRM_Type__c = 'Message';
 
-        if (entry.messageText != null && entry.messageText.startsWith(PREFIX_VEILEDER)) {
+        String senderRole = entry.sender == null ? null : entry.sender.role;
+
+        if ('Agent'.equalsIgnoreCase(senderRole)) {
             String senderSubject = normalizeUserId(entry.sender == null ? null : entry.sender.subject);
             User navUser = senderSubject == null ? null : navUserInfoByUserId.get(senderSubject);
 
@@ -494,7 +398,8 @@ public class NKS_ConversationEntryController {
         if (messageText.startsWith(PREFIX_VEILEDER)) {
             return messageText.substring(PREFIX_VEILEDER.length()).trim();
         }
-        return messageText;
+
+        return messageText.trim();
     }
 
     private static void insertMessages(List<Message__c> messages) {
@@ -533,18 +438,6 @@ public class NKS_ConversationEntryController {
                 CRM_ApplicationDomain.Domain.NKS
             );
         }
-    }
-
-    private static String formatChatbotMessagesAsString(List<ConversationEntry> entries) {
-        List<String> formattedMessages = new List<String>();
-
-        for (ConversationEntry entry : entries) {
-            if (!String.isBlank(entry.messageText)) {
-                formattedMessages.add(entry.messageText);
-            }
-        }
-
-        return String.join(formattedMessages, '\n');
     }
 
     private static Map<String, User> getNavUserInfoByUserId() {

--- a/force-app/main/default/classes/NKS_ConversationEntryController.cls
+++ b/force-app/main/default/classes/NKS_ConversationEntryController.cls
@@ -15,7 +15,6 @@ public class NKS_ConversationEntryController {
         String queryDirection,
         Integer recordLimit
     ) {
-
         try {
             if (msgSessions == null || msgSessions.isEmpty()) {
                 return;

--- a/force-app/main/default/classes/NKS_ConversationEntryController_Test.cls
+++ b/force-app/main/default/classes/NKS_ConversationEntryController_Test.cls
@@ -3,6 +3,7 @@ private class NKS_ConversationEntryController_Test {
     @TestSetup
     static void makeData() {
         User thisUser = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+
         System.runAs(thisUser) {
             MessagingChannel msgChannel = new MessagingChannel();
             msgChannel.MasterLabel = 'TestChannel';
@@ -32,56 +33,181 @@ private class NKS_ConversationEntryController_Test {
     }
 
     @isTest
-    static void testConvertConversationEntries() {
+    static void testConvertConversationEntries_authenticatedChat_createsOnlyAgentChatMessages() {
         MessagingSession messagingSession = [
-            SELECT Id, CRM_Authentication_Status__c
+            SELECT Id, CRM_Authentication_Status__c, NKS_Authentication_Timestamp__c
             FROM MessagingSession
             LIMIT 1
         ];
+
         messagingSession.CRM_Authentication_Status__c = 'Completed';
+        messagingSession.NKS_Authentication_Timestamp__c = Datetime.now();
+        update messagingSession;
+
         String messagingSessionId = messagingSession.Id;
 
         String jsonResponse =
             '{' +
-            '"conversationEntries":[{' +
-            '"clientDuration":0,"clientTimestamp":1732111810339,"identifier":"f895ea81-4e7a-4630-94d5-3de815cdaa95","messageText":"Frida: Første chatbotmelding fra Frida.","relatedRecords":["' +
+            '"conversationEntries":[' +
+            '{' +
+            '"clientDuration":0,' +
+            '"clientTimestamp":1732111810339,' +
+            '"identifier":"entry1",' +
+            '"messageText":"Frida: Hei! Jeg heter Frida og er NAVs chatbot.\\nFrida: Hva lurer du på?\\nBruker: menneske\\nFrida: Det er mange som trenger hjelp fra oss nå.",' +
+            '"relatedRecords":["' +
             messagingSessionId +
-            '"],"sender":{"appType":"iamessage","role":"EndUser","subject":"v2/iamessage/UNAUTH/NA/uid:66823427-6991-4b41-b932-605b3ad2dd7c"},"serverReceivedTimestamp":1732111810339},' +
-            '{"clientDuration":0,"clientTimestamp":1732111810439,"identifier":"f895ea81-4e7a-4630-94d5-3de815cdaa95","messageText":"Tidligere melding fra bruker.","relatedRecords":["' +
+            '"],' +
+            '"sender":{"appType":"iamessage","role":"EndUser","subject":"v2/iamessage/UNAUTH/NA/uid:66823427-6991-4b41-b932-605b3ad2dd7c"},' +
+            '"serverReceivedTimestamp":1732111810339' +
+            '},' +
+            '{' +
+            '"clientDuration":0,' +
+            '"clientTimestamp":1732111810707,' +
+            '"identifier":"entry2",' +
+            '"messageText":"Frida: Jeg setter deg over, et øyeblikk.\\nFrida: Det er mange som vil snakke med oss nå. Hold chatten åpen og følg med, så svarer vi deg så snart vi kan.",' +
+            '"relatedRecords":["' +
             messagingSessionId +
-            '"],"sender":{"appType":"iamessage","role":"EndUser","subject":"v2/iamessage/UNAUTH/NA/uid:66823427-6991-4b41-b932-605b3ad2dd7c"},"serverReceivedTimestamp":1732111810439},' +
-            '{"clientDuration":0,"clientTimestamp":1732111810607,"identifier":"f895ea81-4e7a-4630-94d5-3de815cdaa95","messageText":"Tidligere melding fra bruker.","relatedRecords":["' +
+            '"],' +
+            '"sender":{"appType":"iamessage","role":"System","subject":"system-user"},' +
+            '"serverReceivedTimestamp":1732111810707' +
+            '},' +
+            '{' +
+            '"clientDuration":0,' +
+            '"clientTimestamp":1732111834844,' +
+            '"identifier":"entry3",' +
+            '"messageText":"Melding fra veileder.",' +
+            '"relatedRecords":["' +
             messagingSessionId +
-            '"],"sender":{"appType":"iamessage","role":"Agent","subject":"v2/iamessage/UNAUTH/NA/uid:66823427-6991-4b41-b932-605b3ad2dd7c"},"serverReceivedTimestamp":1732111810607},' +
-            '{"clientDuration":0,"clientTimestamp":1732111810707,"identifier":"f895ea81-4e7a-4630-94d5-3de815cdaa95","messageText":"Velkommen til chat med NAV","relatedRecords":["' +
+            '"],' +
+            '"sender":{"appType":"agent","role":"Agent","subject":"0052o000009d7J9"},' +
+            '"serverReceivedTimestamp":1732111834844' +
+            '},' +
+            '{' +
+            '"clientDuration":0,' +
+            '"clientTimestamp":1732111856855,' +
+            '"identifier":"entry4",' +
+            '"messageText":"Melding fra bruker.",' +
+            '"relatedRecords":["' +
             messagingSessionId +
-            '"],"sender":{"appType":"iamessage","role":"System","subject":"v2/iamessage/UNAUTH/NA/uid:66823427-6991-4b41-b932-605b3ad2dd7c"},"serverReceivedTimestamp":1732111810707},' +
-            '{"clientDuration":0,"clientTimestamp":1732111834844,"identifier":"adcf753e-bb2b-4a00-a6c6-7ebcf683df2c","messageText":"Melding fra veileder.","relatedRecords":["' +
-            messagingSessionId +
-            '"],"sender":{"appType":"agent","role":"Agent","subject":"0052o000009d7J9"},"serverReceivedTimestamp":1732111834844},' +
-            '{"clientDuration":0,"clientTimestamp":1732111856855,"identifier":"ae84faf0-7cd5-4870-a860-5698c8508b7c","messageText":"Melding fra bruker.","relatedRecords":["' +
-            messagingSessionId +
-            '"],"sender":{"appType":"iamessage","role":"EndUser","subject":"v2/iamessage/UNAUTH/NA/uid:66823427-6991-4b41-b932-605b3ad2dd7c"},"serverReceivedTimestamp":1732111856855}' +
+            '"],' +
+            '"sender":{"appType":"iamessage","role":"EndUser","subject":"v2/iamessage/UNAUTH/NA/uid:66823427-6991-4b41-b932-605b3ad2dd7c"},' +
+            '"serverReceivedTimestamp":1732111856855' +
+            '}' +
             ']}';
 
         Test.setMock(HttpCalloutMock.class, new SingleRequestMock(200, 'OK', jsonResponse, null));
 
         Test.startTest();
+        NKS_ConversationEntryController.convertConversationEntries(
+            new List<MessagingSession>{ messagingSession },
+            null,
+            null,
+            'FromStart',
+            1000
+        );
+        Test.stopTest();
+
+        Thread__c thread = [
+            SELECT Id, CRM_Additional_Information__c, CRM_isActive__c, CRM_Closed_Date__c
+            FROM Thread__c
+            WHERE CRM_Related_Object__c = :messagingSessionId
+            LIMIT 1
+        ];
+
+        List<Message__c> messages = [
+            SELECT Id, CRM_Message_Text__c, CRM_Type__c, CRM_From_Contact__c, CRM_From_User__c
+            FROM Message__c
+            WHERE CRM_Thread__c = :thread.Id
+            ORDER BY CreatedDate ASC
+        ];
+
+        Assert.areEqual(3, messages.size(), 'Expected 3 messages: 1 auth event + 2 real chat messages.');
+
+        Assert.areEqual('Event', messages[0].CRM_Type__c, 'First message should be auth event.');
+        Assert.areEqual('Startet innlogget chat', messages[0].CRM_Message_Text__c, 'Expected Norwegian auth text.');
+
+        Assert.areEqual('Message', messages[1].CRM_Type__c, 'Second record should be a chat message.');
+        Assert.areEqual('Melding fra veileder.', messages[1].CRM_Message_Text__c, 'Agent message should be created.');
+
+        Assert.areEqual('Message', messages[2].CRM_Type__c, 'Third record should be a chat message.');
+        Assert.areEqual('Melding fra bruker.', messages[2].CRM_Message_Text__c, 'User message should be created.');
+
+        Assert.isTrue(
+            thread.CRM_Additional_Information__c.contains('Frida: Hei! Jeg heter Frida og er NAVs chatbot.'),
+            'Frida history should be stored in additional information.'
+        );
+        Assert.isTrue(
+            thread.CRM_Additional_Information__c.contains('Bruker: menneske'),
+            'Pre-chat user lines should remain in additional information.'
+        );
+        Assert.isTrue(
+            !thread.CRM_Additional_Information__c.contains('Melding fra veileder.'),
+            'Actual agent chat should not be stored in additional information.'
+        );
+        Assert.isTrue(
+            !thread.CRM_Additional_Information__c.contains('Melding fra bruker.'),
+            'Actual user chat with agent should not be stored in additional information.'
+        );
+        Assert.areEqual(false, thread.CRM_isActive__c, 'Thread should be closed after processing.');
+        Assert.areEqual(true, thread.CRM_Closed_Date__c != null, 'Thread closed date should be set.');
+    }
+
+    @isTest
+    static void testConvertConversationEntries_skipsNonAuthenticatedSession() {
+        MessagingSession messagingSession = [
+            SELECT Id, CRM_Authentication_Status__c
+            FROM MessagingSession
+            LIMIT 1
+        ];
+
+        messagingSession.CRM_Authentication_Status__c = 'Not Started';
         update messagingSession;
+
+        String messagingSessionId = messagingSession.Id;
+
+        String jsonResponse =
+            '{' +
+            '"conversationEntries":[' +
+            '{' +
+            '"clientDuration":0,' +
+            '"clientTimestamp":1732111810339,' +
+            '"identifier":"entry1",' +
+            '"messageText":"Frida: Hei",' +
+            '"relatedRecords":["' +
+            messagingSessionId +
+            '"],' +
+            '"sender":{"appType":"iamessage","role":"System","subject":"system-user"},' +
+            '"serverReceivedTimestamp":1732111810339' +
+            '}' +
+            ']}';
+
+        Test.setMock(HttpCalloutMock.class, new SingleRequestMock(200, 'OK', jsonResponse, null));
+
+        Test.startTest();
+        NKS_ConversationEntryController.convertConversationEntries(
+            new List<MessagingSession>{ messagingSession },
+            null,
+            null,
+            'FromStart',
+            1000
+        );
         Test.stopTest();
 
         Thread__c thread = [
             SELECT Id, CRM_Additional_Information__c
             FROM Thread__c
             WHERE CRM_Related_Object__c = :messagingSessionId
+            LIMIT 1
         ];
-        List<Message__c> messages = [SELECT Id FROM Message__c WHERE CRM_Thread__c = :thread.Id];
 
-        Assert.isTrue(messages.size() == 4, '4 messages should be inserted (including auth event message).');
-        Assert.isTrue(
-            thread.CRM_Additional_Information__c.contains('Frida: Første chatbotmelding fra Frida.'),
-            'Fridalog should be added to the field.'
-        );
+        List<Message__c> messages = [
+            SELECT Id
+            FROM Message__c
+            WHERE CRM_Thread__c = :thread.Id
+        ];
+
+        Assert.areEqual(0, messages.size(), 'No messages should be created for non-authenticated chats.');
+        Assert.areEqual(null, thread.CRM_Additional_Information__c, 'Thread should not be processed.');
     }
 
     @isTest
@@ -101,25 +227,18 @@ private class NKS_ConversationEntryController_Test {
 
         String jsonResponse =
             '{' +
-            '"conversationEntries":[{' +
-            '"clientDuration":0,"clientTimestamp":1732111810339,"identifier":"f895ea81-4e7a-4630-94d5-3de815cdaa95","messageText":"Frida: Første chatbotmelding fra Frida.","relatedRecords":["' +
+            '"conversationEntries":[' +
+            '{' +
+            '"clientDuration":0,' +
+            '"clientTimestamp":1732111810339,' +
+            '"identifier":"entry1",' +
+            '"messageText":"Frida: Første chatbotmelding fra Frida.",' +
+            '"relatedRecords":["' +
             messagingSessionId +
-            '"],"sender":{"appType":"iamessage","role":"EndUser","subject":"v2/iamessage/UNAUTH/NA/uid:66823427-6991-4b41-b932-605b3ad2dd7c"},"serverReceivedTimestamp":1732111810339},' +
-            '{"clientDuration":0,"clientTimestamp":1732111810439,"identifier":"f895ea81-4e7a-4630-94d5-3de815cdaa95","messageText":"Tidligere melding fra bruker.","relatedRecords":["' +
-            messagingSessionId +
-            '"],"sender":{"appType":"iamessage","role":"EndUser","subject":"v2/iamessage/UNAUTH/NA/uid:66823427-6991-4b41-b932-605b3ad2dd7c"},"serverReceivedTimestamp":1732111810439},' +
-            '{"clientDuration":0,"clientTimestamp":1732111810607,"identifier":"f895ea81-4e7a-4630-94d5-3de815cdaa95","messageText":"Tidligere melding fra bruker.","relatedRecords":["' +
-            messagingSessionId +
-            '"],"sender":{"appType":"iamessage","role":"Agent","subject":"v2/iamessage/UNAUTH/NA/uid:66823427-6991-4b41-b932-605b3ad2dd7c"},"serverReceivedTimestamp":1732111810607},' +
-            '{"clientDuration":0,"clientTimestamp":1732111810707,"identifier":"f895ea81-4e7a-4630-94d5-3de815cdaa95","messageText":"Velkommen til chat med NAV","relatedRecords":["' +
-            messagingSessionId +
-            '"],"sender":{"appType":"iamessage","role":"System","subject":"v2/iamessage/UNAUTH/NA/uid:66823427-6991-4b41-b932-605b3ad2dd7c"},"serverReceivedTimestamp":1732111810707},' +
-            '{"clientDuration":0,"clientTimestamp":1732111834844,"identifier":"adcf753e-bb2b-4a00-a6c6-7ebcf683df2c","messageText":"Melding fra veileder.","relatedRecords":["' +
-            messagingSessionId +
-            '"],"sender":{"appType":"agent","role":"Agent","subject":"0052o000009d7J9"},"serverReceivedTimestamp":1732111834844},' +
-            '{"clientDuration":0,"clientTimestamp":1732111856855,"identifier":"ae84faf0-7cd5-4870-a860-5698c8508b7c","messageText":"Melding fra bruker.","relatedRecords":["' +
-            messagingSessionId +
-            '"],"sender":{"appType":"iamessage","role":"EndUser","subject":"v2/iamessage/UNAUTH/NA/uid:66823427-6991-4b41-b932-605b3ad2dd7c"},"serverReceivedTimestamp":1732111856855}' +
+            '"],' +
+            '"sender":{"appType":"iamessage","role":"System","subject":"system-user"},' +
+            '"serverReceivedTimestamp":1732111810339' +
+            '}' +
             ']}';
 
         Test.setMock(HttpCalloutMock.class, new SingleRequestMock(200, 'OK', jsonResponse, null));

--- a/force-app/main/default/classes/NKS_ConversationEntryQueueable.cls
+++ b/force-app/main/default/classes/NKS_ConversationEntryQueueable.cls
@@ -1,18 +1,18 @@
-public with sharing class NKS_ConversationEntryQueueable implements Queueable, Database.AllowsCallouts {
-    List<MessagingSession> messagingSessions;
-    Long startTimestamp;
-    Long endTimestamp;
-    String queryDirection;
-    Integer recordLimit;
+public class NKS_ConversationEntryQueueable implements Queueable, Database.AllowsCallouts {
+    private List<Id> messagingSessionIds;
+    private Long startTimestamp;
+    private Long endTimestamp;
+    private String queryDirection;
+    private Integer recordLimit;
 
     public NKS_ConversationEntryQueueable(
-        List<MessagingSession> messagingSessions,
+        List<Id> messagingSessionIds,
         Long startTimestamp,
         Long endTimestamp,
         String queryDirection,
         Integer recordLimit
     ) {
-        this.messagingSessions = messagingSessions;
+        this.messagingSessionIds = messagingSessionIds;
         this.startTimestamp = startTimestamp;
         this.endTimestamp = endTimestamp;
         this.queryDirection = queryDirection;
@@ -20,8 +20,14 @@ public with sharing class NKS_ConversationEntryQueueable implements Queueable, D
     }
 
     public void execute(QueueableContext context) {
+        List<MessagingSession> sessions = [
+            SELECT Id
+            FROM MessagingSession
+            WHERE Id IN :messagingSessionIds
+        ];
+
         NKS_ConversationEntryController.convertConversationEntries(
-            messagingSessions,
+            sessions,
             startTimestamp,
             endTimestamp,
             queryDirection,

--- a/force-app/main/default/classes/NKS_ConversationEntryService.cls
+++ b/force-app/main/default/classes/NKS_ConversationEntryService.cls
@@ -1,5 +1,5 @@
 public class NKS_ConversationEntryService {
-    private static final String API_VERSION = 'v62.0';
+    private static final String API_VERSION = 'v66.0';
 
     public static HttpResponse getConversationEntryMessages(
         String conversationIdentifier,

--- a/force-app/main/default/classes/NKS_MessagingSessionHandler.cls
+++ b/force-app/main/default/classes/NKS_MessagingSessionHandler.cls
@@ -3,26 +3,21 @@ global with sharing class NKS_MessagingSessionHandler extends MyTriggers {
     private static final String LOG_PREFIX = 'NKS_MessagingSessionHandler';
 
     global override void onAfterUpdate(Map<Id, sObject> triggerOldMap) {
+        List<String> fieldNamesToCheck = new List<String>{ 'EndTime', 'Status', 'CRM_Authentication_Status__c' };
         List<Id> messagingSessionIdsToConvert = new List<Id>();
 
         try {
             for (MessagingSession newRecord : (List<MessagingSession>) records) {
                 MessagingSession oldRecord = (MessagingSession) triggerOldMap.get(newRecord.Id);
 
-                Boolean relevantFieldChanged =
-                    newRecord.EndTime != oldRecord.EndTime ||
-                    newRecord.Status != oldRecord.Status ||
-                    newRecord.CRM_Authentication_Status__c != oldRecord.CRM_Authentication_Status__c;
-
-                Boolean shouldConvert =
-                    relevantFieldChanged &&
+                if (
+                    MyTriggers.hasChangedFields(fieldNamesToCheck, newRecord, oldRecord) &&
                     newRecord.EndTime != null &&
                     newRecord.EndTime <= Datetime.now() &&
                     newRecord.CRM_Authentication_Status__c == 'Completed' &&
                     (newRecord.Status == 'Ended' ||
-                    newRecord.Status == 'Inactive');
-
-                if (shouldConvert) {
+                    newRecord.Status == 'Inactive')
+                ) {
                     messagingSessionIdsToConvert.add(newRecord.Id);
                 }
             }

--- a/force-app/main/default/classes/NKS_MessagingSessionHandler.cls
+++ b/force-app/main/default/classes/NKS_MessagingSessionHandler.cls
@@ -1,27 +1,92 @@
 global with sharing class NKS_MessagingSessionHandler extends MyTriggers {
     private static LoggerUtility logger = new LoggerUtility('Messaging');
+    private static final String LOG_PREFIX = 'NKS_MessagingSessionHandler';
 
     global override void onAfterUpdate(Map<Id, sObject> triggerOldMap) {
-        List<String> fieldNamesToCheck = new List<String>{ 'EndTime', 'Status', 'CRM_Authentication_Status__c' };
-        List<MessagingSession> messagingSessionsToConvert = new List<MessagingSession>();
+        List<Id> messagingSessionIdsToConvert = new List<Id>();
 
-        for (MessagingSession newRecord : (List<MessagingSession>) records) {
-            MessagingSession oldRecord = (MessagingSession) triggerOldMap.get(newRecord.Id);
-            if (
-                MyTriggers.hasChangedFields(fieldNamesToCheck, newRecord, oldRecord) &&
-                newRecord.EndTime <= Datetime.now() &&
-                newRecord.CRM_Authentication_Status__c == 'Completed' &&
-                (newRecord.Status == 'Ended' ||
-                newRecord.Status == 'Inactive')
-            ) {
-                messagingSessionsToConvert.add(newRecord);
+        logger.info(
+            LOG_PREFIX +
+                '.onAfterUpdate START | records.size=' +
+                (((List<MessagingSession>) records) == null ? 0 : ((List<MessagingSession>) records).size()),
+            null,
+            CRM_ApplicationDomain.Domain.NKS
+        );
+
+        try {
+            for (MessagingSession newRecord : (List<MessagingSession>) records) {
+                MessagingSession oldRecord = (MessagingSession) triggerOldMap.get(newRecord.Id);
+
+                Boolean relevantFieldChanged =
+                    newRecord.EndTime != oldRecord.EndTime ||
+                    newRecord.Status != oldRecord.Status ||
+                    newRecord.CRM_Authentication_Status__c != oldRecord.CRM_Authentication_Status__c;
+
+                Boolean shouldConvert =
+                    relevantFieldChanged &&
+                    newRecord.EndTime != null &&
+                    newRecord.EndTime <= Datetime.now() &&
+                    newRecord.CRM_Authentication_Status__c == 'Completed' &&
+                    (newRecord.Status == 'Ended' ||
+                    newRecord.Status == 'Inactive');
+
+                logger.info(
+                    LOG_PREFIX +
+                        '.onAfterUpdate | sessionId=' +
+                        newRecord.Id +
+                        ' | oldEndTime=' +
+                        String.valueOf(oldRecord.EndTime) +
+                        ' | newEndTime=' +
+                        String.valueOf(newRecord.EndTime) +
+                        ' | oldStatus=' +
+                        oldRecord.Status +
+                        ' | newStatus=' +
+                        newRecord.Status +
+                        ' | oldAuthStatus=' +
+                        oldRecord.CRM_Authentication_Status__c +
+                        ' | newAuthStatus=' +
+                        newRecord.CRM_Authentication_Status__c +
+                        ' | relevantFieldChanged=' +
+                        relevantFieldChanged +
+                        ' | shouldConvert=' +
+                        shouldConvert,
+                    null,
+                    CRM_ApplicationDomain.Domain.NKS
+                );
+
+                if (shouldConvert) {
+                    messagingSessionIdsToConvert.add(newRecord.Id);
+                }
             }
-        }
 
-        if (messagingSessionsToConvert.size() > 0) {
-            System.enqueueJob(
-                new NKS_ConversationEntryQueueable(messagingSessionsToConvert, null, null, 'FromStart', 1000)
+            logger.info(
+                LOG_PREFIX +
+                    '.onAfterUpdate | messagingSessionIdsToConvert=' +
+                    JSON.serialize(messagingSessionIdsToConvert),
+                null,
+                CRM_ApplicationDomain.Domain.NKS
             );
+
+            if (!messagingSessionIdsToConvert.isEmpty()) {
+                System.enqueueJob(
+                    new NKS_ConversationEntryQueueable(messagingSessionIdsToConvert, null, null, 'FromStart', 1000)
+                );
+
+                logger.info(LOG_PREFIX + '.onAfterUpdate | Queueable enqueued', null, CRM_ApplicationDomain.Domain.NKS);
+            }
+        } catch (Exception e) {
+            logger.error(
+                LOG_PREFIX +
+                    '.onAfterUpdate ERROR' +
+                    ' | message=' +
+                    e.getMessage() +
+                    ' | stack=' +
+                    e.getStackTraceString(),
+                null,
+                CRM_ApplicationDomain.Domain.NKS
+            );
+        } finally {
+            logger.publish();
         }
     }
 }

--- a/force-app/main/default/classes/NKS_MessagingSessionHandler.cls
+++ b/force-app/main/default/classes/NKS_MessagingSessionHandler.cls
@@ -5,14 +5,6 @@ global with sharing class NKS_MessagingSessionHandler extends MyTriggers {
     global override void onAfterUpdate(Map<Id, sObject> triggerOldMap) {
         List<Id> messagingSessionIdsToConvert = new List<Id>();
 
-        logger.info(
-            LOG_PREFIX +
-                '.onAfterUpdate START | records.size=' +
-                (((List<MessagingSession>) records) == null ? 0 : ((List<MessagingSession>) records).size()),
-            null,
-            CRM_ApplicationDomain.Domain.NKS
-        );
-
         try {
             for (MessagingSession newRecord : (List<MessagingSession>) records) {
                 MessagingSession oldRecord = (MessagingSession) triggerOldMap.get(newRecord.Id);
@@ -30,49 +22,15 @@ global with sharing class NKS_MessagingSessionHandler extends MyTriggers {
                     (newRecord.Status == 'Ended' ||
                     newRecord.Status == 'Inactive');
 
-                logger.info(
-                    LOG_PREFIX +
-                        '.onAfterUpdate | sessionId=' +
-                        newRecord.Id +
-                        ' | oldEndTime=' +
-                        String.valueOf(oldRecord.EndTime) +
-                        ' | newEndTime=' +
-                        String.valueOf(newRecord.EndTime) +
-                        ' | oldStatus=' +
-                        oldRecord.Status +
-                        ' | newStatus=' +
-                        newRecord.Status +
-                        ' | oldAuthStatus=' +
-                        oldRecord.CRM_Authentication_Status__c +
-                        ' | newAuthStatus=' +
-                        newRecord.CRM_Authentication_Status__c +
-                        ' | relevantFieldChanged=' +
-                        relevantFieldChanged +
-                        ' | shouldConvert=' +
-                        shouldConvert,
-                    null,
-                    CRM_ApplicationDomain.Domain.NKS
-                );
-
                 if (shouldConvert) {
                     messagingSessionIdsToConvert.add(newRecord.Id);
                 }
             }
 
-            logger.info(
-                LOG_PREFIX +
-                    '.onAfterUpdate | messagingSessionIdsToConvert=' +
-                    JSON.serialize(messagingSessionIdsToConvert),
-                null,
-                CRM_ApplicationDomain.Domain.NKS
-            );
-
             if (!messagingSessionIdsToConvert.isEmpty()) {
                 System.enqueueJob(
                     new NKS_ConversationEntryQueueable(messagingSessionIdsToConvert, null, null, 'FromStart', 1000)
                 );
-
-                logger.info(LOG_PREFIX + '.onAfterUpdate | Queueable enqueued', null, CRM_ApplicationDomain.Domain.NKS);
             }
         } catch (Exception e) {
             logger.error(

--- a/force-app/main/default/permissionsets/NKS_Chat_Permissions.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/NKS_Chat_Permissions.permissionset-meta.xml
@@ -21,6 +21,10 @@
         <apexClass>ChatAuthControllerExperience</apexClass>
         <enabled>true</enabled>
     </classAccesses>
+    <classAccesses>
+        <apexClass>NKS_ConversationEntryController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
     <fieldPermissions>
         <editable>false</editable>
         <field>Case.NKS_Conversation_Stored__c</field>

--- a/force-app/main/default/permissionsets/NKS_Chat_Permissions.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/NKS_Chat_Permissions.permissionset-meta.xml
@@ -21,10 +21,6 @@
         <apexClass>ChatAuthControllerExperience</apexClass>
         <enabled>true</enabled>
     </classAccesses>
-    <classAccesses>
-        <apexClass>NKS_ConversationEntryController</apexClass>
-        <enabled>true</enabled>
-    </classAccesses>
     <fieldPermissions>
         <editable>false</editable>
         <field>Case.NKS_Conversation_Stored__c</field>


### PR DESCRIPTION
flyttet prosesseringen til queueable slik at tråden finnes før oppslag
rettet queueable-konstruktøren til å bruke List<Id>
gjorde prosessering av kun autentiserte chatter mer robust
rettet 15-tegn vs 18-tegn bruker-ID for veileder
endret parsing slik at multiline-transkript splittes på Frida:, Bruker: Veileder
kun chatbot-linjer lagres i CRM_Additional_Information__c
